### PR TITLE
feat: include course assignments in professor edit PUT

### DIFF
--- a/app/(dashboard)/professors/[id]/edit/page.tsx
+++ b/app/(dashboard)/professors/[id]/edit/page.tsx
@@ -171,34 +171,23 @@ export default function EditProfessorPage() {
 
     setIsLoading(true);
     try {
-      // Update basic info
-      await apiClient.updateProfessor(professorId, {
+      // Update basic info + course assignments in one call.
+      // course_ids is admin/super_admin only; this form is gated by AdminOnly,
+      // so we always send the full selected list (replace, not delta).
+      const updated = await apiClient.updateProfessor(professorId, {
         email: formData.email,
         firstName: formData.firstName,
         lastName: formData.lastName,
         isAdmin: formData.isAdmin,
         ...(isSuperAdmin && formData.username ? { username: formData.username } : {}),
         ...(isSuperAdmin && formData.universityId ? { universityId: formData.universityId } : {}),
+        courseIds: assignedCourseIds,
       });
 
-      // Update course assignments
-      const toAdd = assignedCourseIds.filter(id => !originalAssignedCourseIds.includes(id));
-      const toRemove = originalAssignedCourseIds.filter(id => !assignedCourseIds.includes(id));
-
-      for (const courseId of toAdd) {
-        try {
-          await apiClient.assignProfessorToCourse(courseId, professorId);
-        } catch (error) {
-          console.error(`Error assigning course ${courseId}:`, error);
-        }
-      }
-
-      for (const courseId of toRemove) {
-        try {
-          await apiClient.unassignProfessorFromCourse(courseId, professorId);
-        } catch (error) {
-          console.error(`Error unassigning course ${courseId}:`, error);
-        }
+      // Refresh state from response instead of re-fetching.
+      if (updated.assignedCourseIds) {
+        setAssignedCourseIds(updated.assignedCourseIds);
+        setOriginalAssignedCourseIds(updated.assignedCourseIds);
       }
 
       // Handle password reset if requested
@@ -222,7 +211,13 @@ export default function EditProfessorPage() {
       }
     } catch (error: any) {
       console.error('Failed to update professor:', error);
-      toast.error(error.message || t('updateError'));
+      const msg: string = error?.message || '';
+      // Surface course-assignment 400s inline on the courses field.
+      if (error?.status === 400 && /^Course \d+ (not found|does not belong)/i.test(msg)) {
+        setErrors((prev) => ({ ...prev, assignedCourses: msg }));
+      } else {
+        toast.error(msg || t('updateError'));
+      }
     } finally {
       setIsLoading(false);
     }
@@ -366,30 +361,38 @@ export default function EditProfessorPage() {
                   {t('noCoursesAvailable')}
                 </p>
               ) : (
-                <MultiSelect
-                  options={courses.map((course) => ({
-                    value: String(course.id),
-                    label: course.code ? `${course.name} (${course.code})` : course.name,
-                  }))}
-                  selected={assignedCourseIds.map(String)}
-                  onChange={(selected) => {
-                    const courseIds = selected.map(Number);
-                    courseIds.forEach((courseId) => {
-                      if (!assignedCourseIds.includes(courseId)) {
-                        toggleCourse(courseId);
+                <>
+                  <MultiSelect
+                    options={courses.map((course) => ({
+                      value: String(course.id),
+                      label: course.code ? `${course.name} (${course.code})` : course.name,
+                    }))}
+                    selected={assignedCourseIds.map(String)}
+                    onChange={(selected) => {
+                      const courseIds = selected.map(Number);
+                      courseIds.forEach((courseId) => {
+                        if (!assignedCourseIds.includes(courseId)) {
+                          toggleCourse(courseId);
+                        }
+                      });
+                      assignedCourseIds.forEach((courseId) => {
+                        if (!courseIds.includes(courseId)) {
+                          toggleCourse(courseId);
+                        }
+                      });
+                      if (errors.assignedCourses) {
+                        setErrors((prev) => ({ ...prev, assignedCourses: '' }));
                       }
-                    });
-                    assignedCourseIds.forEach((courseId) => {
-                      if (!courseIds.includes(courseId)) {
-                        toggleCourse(courseId);
-                      }
-                    });
-                  }}
-                  placeholder={t('selectCourses') || 'Select courses...'}
-                  searchPlaceholder={t('searchCourses') || 'Search courses...'}
-                  emptyMessage={t('noCoursesFound') || 'No courses found.'}
-                  disabled={isLoading}
-                />
+                    }}
+                    placeholder={t('selectCourses') || 'Select courses...'}
+                    searchPlaceholder={t('searchCourses') || 'Search courses...'}
+                    emptyMessage={t('noCoursesFound') || 'No courses found.'}
+                    disabled={isLoading}
+                  />
+                  {errors.assignedCourses && (
+                    <p className="text-sm text-destructive mt-2">{errors.assignedCourses}</p>
+                  )}
+                </>
               )}
             </CardContent>
           </Card>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -877,8 +877,7 @@ class TutoriaAPIClient {
   }
 
   async updateProfessor(id: number, data: ProfessorUpdate): Promise<Professor> {
-    // Use unified Users API
-    interface BackendUserResponse {
+    interface BackendProfessorResponse {
       userId: number;
       username: string;
       email: string;
@@ -894,15 +893,18 @@ class TutoriaAPIClient {
       lastLoginAt?: string | null;
       languagePreference?: string;
       themePreference?: string;
+      assignedCourseIds?: number[];
     }
 
-    const response = await this.put<BackendUserResponse>(`/api/users/${id}`, {
+    const body: Record<string, unknown> = {
       email: data.email,
       firstName: data.firstName,
       lastName: data.lastName,
-    });
+    };
+    if (data.courseIds !== undefined) body.courseIds = data.courseIds;
 
-    // Map backend UserResponse to Professor interface
+    const response = await this.put<BackendProfessorResponse>(`/api/professors/${id}`, body);
+
     return {
       id: response.userId,
       username: response.username,
@@ -918,6 +920,7 @@ class TutoriaAPIClient {
       lastLoginAt: response.lastLoginAt,
       languagePreference: response.languagePreference,
       themePreference: response.themePreference,
+      assignedCourseIds: response.assignedCourseIds,
     };
   }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -472,6 +472,8 @@ export interface ProfessorUpdate {
   firstName?: string;
   lastName?: string;
   isAdmin?: boolean;
+  // null = leave assignments unchanged, [] = unassign all, [ids] = replace
+  courseIds?: number[] | null;
 }
 
 // Professor Agent Types


### PR DESCRIPTION
Wire course_ids through the unified PUT /api/professors/{id} call and use
the response's assignedCourseIds to refresh state, replacing the per-course
assign/unassign loop. Course-related 400s ("Course {id} not found", "Course
{id} does not belong to the professor's university") surface inline on the
courses field.

https://claude.ai/code/session_015ZeFNzLER2zacy2kaadJAU