### PR TITLE
feat(majors): manage degree programs + tag courses with them

### DIFF
--- a/app/(dashboard)/courses/[id]/edit/page.tsx
+++ b/app/(dashboard)/courses/[id]/edit/page.tsx
@@ -7,11 +7,13 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { MultiSelect } from '@/components/ui/multi-select';
+import { FormField, FormItem, FormLabel } from '@/components/ui/form';
 import { PageHeader } from '@/components/layout/page-header';
 import { AdminProfessorOnly } from '@/components/auth/role-guard';
 import { apiClient } from '@/lib/api';
 import { ArrowLeft, Loader2 } from 'lucide-react';
-import type { Course, CourseUpdate, BreadcrumbItem, University } from '@/lib/types';
+import type { Course, CourseUpdate, BreadcrumbItem, University, Major } from '@/lib/types';
 import { parseExternalCourseId } from '@/components/forms/course-form';
 
 export default function EditCoursePage() {
@@ -39,14 +41,21 @@ export default function EditCoursePage() {
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [isLoading, setIsLoading] = useState(false);
   const [isLoadingData, setIsLoadingData] = useState(true);
+  const [majors, setMajors] = useState<Major[]>([]);
+  const [selectedMajorIds, setSelectedMajorIds] = useState<string[]>([]);
+  const [originalMajorIds, setOriginalMajorIds] = useState<string[]>([]);
 
   // Check if form has changes
   const hasChanges = () => {
+    const majorsChanged =
+      selectedMajorIds.length !== originalMajorIds.length ||
+      selectedMajorIds.some(id => !originalMajorIds.includes(id));
     return (
       formData.name !== originalFormData.name ||
       formData.code !== originalFormData.code ||
       formData.description !== originalFormData.description ||
-      formData.externalCourseId !== originalFormData.externalCourseId
+      formData.externalCourseId !== originalFormData.externalCourseId ||
+      majorsChanged
     );
   };
 
@@ -63,13 +72,23 @@ export default function EditCoursePage() {
       };
       setFormData(initialData);
       setOriginalFormData(initialData);
-      // Load university to check hasAssignments
+      // Pre-select the course's current majors
+      const currentMajorIds = (data.majors ?? []).map(m => String(m.id));
+      setSelectedMajorIds(currentMajorIds);
+      setOriginalMajorIds(currentMajorIds);
+      // Load university (to check hasAssignments) and its majors list
       if (data.universityId) {
         try {
           const uni = await apiClient.getUniversity(data.universityId);
           setUniversity(uni);
         } catch {
           // Non-critical
+        }
+        try {
+          const list = await apiClient.getUniversityMajors(data.universityId);
+          setMajors(list);
+        } catch {
+          // Non-critical: majors are optional
         }
       }
     } catch (error) {
@@ -121,7 +140,7 @@ export default function EditCoursePage() {
 
     setIsLoading(true);
     try {
-      await apiClient.updateCourse(courseId, formData);
+      await apiClient.updateCourse(courseId, { ...formData, majorIds: selectedMajorIds.map(Number) });
       router.push(`/courses/${courseId}`);
     } catch (error) {
       console.error('Failed to update course:', error);
@@ -259,6 +278,26 @@ export default function EditCoursePage() {
                   <p className="text-xs text-muted-foreground mt-1">{tForm('externalCourseIdHelp')}</p>
                 </div>
               )}
+
+              {/* Majors (degree programs / graduações) this course belongs to */}
+              <FormField>
+                <FormItem>
+                  <FormLabel>
+                    {tForm('majorsLabel')}
+                    <span className="ml-1 text-xs font-normal text-muted-foreground">({tForm('optional')})</span>
+                  </FormLabel>
+                  <MultiSelect
+                    options={majors.map(m => ({ value: String(m.id), label: m.name }))}
+                    selected={selectedMajorIds}
+                    onChange={setSelectedMajorIds}
+                    placeholder={tForm('majorsPlaceholder')}
+                    searchPlaceholder={tForm('majorsSearch')}
+                    emptyMessage={tForm('majorsEmpty')}
+                    disabled={isLoading}
+                  />
+                  <p className="text-xs text-muted-foreground">{tForm('majorsHelp')}</p>
+                </FormItem>
+              </FormField>
 
               {errors.submit && (
                 <p className="text-sm text-destructive">{errors.submit}</p>

--- a/app/(dashboard)/courses/create/page.tsx
+++ b/app/(dashboard)/courses/create/page.tsx
@@ -37,6 +37,7 @@ export default function CreateCoursePage() {
         code: data.code || '',
         description: data.description,
         universityId: 'universityId' in data ? data.universityId : user?.universityId || 1,
+        majorIds: 'majorIds' in data ? data.majorIds : undefined,
       };
 
       const newCourse = await apiClient.createCourse(courseData);

--- a/app/(dashboard)/universities/[id]/page.tsx
+++ b/app/(dashboard)/universities/[id]/page.tsx
@@ -19,19 +19,22 @@ import {
   UserCircle,
   Globe,
   MapPin,
-  FileText
+  FileText,
+  Hash,
+  Loader2
 } from 'lucide-react';
 import { PageHeader } from '@/components/layout/page-header';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
 import { DataTable } from '@/components/shared/data-table';
 import { Loading } from '@/components/ui/loading-spinner';
 import { AdminOnly, ProfessorOnly, SuperAdminOnly } from '@/components/auth/role-guard';
 import { useAuth } from '@/components/auth/auth-provider';
 import { useFetch } from '@/lib/hooks';
 import { formatDateShort } from '@/lib/utils';
-import type { UniversityWithCourses, Course, Professor, TableColumn, BreadcrumbItem, PaginatedResponse } from '@/lib/types';
+import type { UniversityWithCourses, Course, Professor, Major, TableColumn, BreadcrumbItem, PaginatedResponse } from '@/lib/types';
 import { toast } from 'sonner';
 import { useConfirmDialog } from '@/components/ui/confirm-dialog';
 import {
@@ -85,6 +88,65 @@ export default function UniversityDetailsPage() {
 
   // Fetch university details
   const { data: university, loading: universityLoading } = useFetch<UniversityWithCourses>(`/api/universities/${universityId}`);
+
+  // Majors (degree programs / graduações) — managed locally so add/remove is instant
+  const [majors, setMajors] = useState<Major[]>([]);
+  const [newMajorName, setNewMajorName] = useState('');
+  const [majorBusy, setMajorBusy] = useState(false);
+
+  React.useEffect(() => {
+    if (university?.majors) setMajors(university.majors);
+  }, [university?.majors]);
+
+  const handleAddMajor = async () => {
+    const name = newMajorName.trim();
+    if (!name || majorBusy) return;
+    setMajorBusy(true);
+    try {
+      const { apiClient } = await import('@/lib/api');
+      const created = await apiClient.createUniversityMajor(Number(universityId), name);
+      setMajors(prev => [...prev, created].sort((a, b) => a.name.localeCompare(b.name)));
+      setNewMajorName('');
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : t('majors.addError'));
+    } finally {
+      setMajorBusy(false);
+    }
+  };
+
+  const handleDeleteMajor = (major: Major) => {
+    confirm({
+      title: t('majors.deleteConfirm', { name: major.name }),
+      description: t('majors.deleteDescription'),
+      variant: 'destructive',
+      confirmText: tCommon('buttons.delete'),
+      cancelText: tCommon('buttons.cancel'),
+      onConfirm: async () => {
+        try {
+          const { apiClient } = await import('@/lib/api');
+          await apiClient.deleteUniversityMajor(Number(universityId), major.id);
+          setMajors(prev => prev.filter(m => m.id !== major.id));
+        } catch (error) {
+          toast.error(error instanceof Error ? error.message : t('majors.deleteError'));
+        }
+      }
+    });
+  };
+
+  const handleSeedMajors = async () => {
+    if (majorBusy) return;
+    setMajorBusy(true);
+    try {
+      const { apiClient } = await import('@/lib/api');
+      const list = await apiClient.seedUniversityMajors(Number(universityId));
+      setMajors(list);
+      toast.success(t('majors.seedSuccess'));
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : t('majors.seedError'));
+    } finally {
+      setMajorBusy(false);
+    }
+  };
 
   // Build courses API URL with pagination params and filters
   // Backend now handles role-based filtering:
@@ -375,6 +437,14 @@ export default function UniversityDetailsPage() {
                   </div>
                 </div>
 
+                <div className="flex items-start space-x-3">
+                  <Hash className="h-5 w-5 text-muted-foreground mt-0.5" />
+                  <div className="flex-1">
+                    <p className="text-sm font-medium text-muted-foreground">{t('info.id')}</p>
+                    <p className="text-base font-mono">{university.id}</p>
+                  </div>
+                </div>
+
                 {university.contactEmail && (
                   <div className="flex items-start space-x-3">
                     <Mail className="h-5 w-5 text-muted-foreground mt-0.5" />
@@ -543,6 +613,61 @@ export default function UniversityDetailsPage() {
           </Card>
         </AdminOnly>
       </div>
+
+      {/* Majors (degree programs / graduações) */}
+      <AdminOnly>
+        <Card>
+          <CardHeader>
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <CardTitle className="flex items-center gap-2">
+                  <GraduationCap className="h-5 w-5" />
+                  {t('majors.title')}
+                </CardTitle>
+                <CardDescription>{t('majors.description')}</CardDescription>
+              </div>
+              <Button variant="outline" size="sm" onClick={handleSeedMajors} disabled={majorBusy}>
+                {majorBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
+                <span className="ml-1">{t('majors.addDefaults')}</span>
+              </Button>
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex gap-2">
+              <Input
+                value={newMajorName}
+                onChange={(e) => setNewMajorName(e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); handleAddMajor(); } }}
+                placeholder={t('majors.placeholder')}
+                disabled={majorBusy}
+              />
+              <Button onClick={handleAddMajor} disabled={majorBusy || !newMajorName.trim()}>
+                {t('majors.add')}
+              </Button>
+            </div>
+
+            {majors.length === 0 ? (
+              <p className="text-sm text-muted-foreground">{t('majors.empty')}</p>
+            ) : (
+              <div className="flex flex-wrap gap-2">
+                {majors.map((major) => (
+                  <Badge key={major.id} variant="secondary" className="flex items-center gap-1 py-1 pl-3 pr-1">
+                    <span>{major.name}</span>
+                    <button
+                      type="button"
+                      onClick={() => handleDeleteMajor(major)}
+                      className="rounded-full p-0.5 hover:bg-destructive/20 hover:text-destructive transition-colors"
+                      aria-label={t('majors.deleteAria', { name: major.name })}
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </button>
+                  </Badge>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </AdminOnly>
 
       {/* Tabs */}
       <div className="flex space-x-2 border-b">

--- a/components/forms/course-form.tsx
+++ b/components/forms/course-form.tsx
@@ -13,7 +13,7 @@ import { Switch } from '@/components/ui/switch';
 import { useAuth } from '@/components/auth/auth-provider';
 import { apiClient, ApiError } from '@/lib/api';
 import { toast } from 'sonner';
-import type { Course, CourseCreate, CourseUpdate, Professor, University } from '@/lib/types';
+import type { Course, CourseCreate, CourseUpdate, Major, Professor, University } from '@/lib/types';
 
 /** Extract an integer course ID from a plain number string or a URL that contains it. */
 export function parseExternalCourseId(raw: string): string {
@@ -59,6 +59,10 @@ export function CourseForm({ course, onSubmit, onCancel, isLoading = false, init
   const [professors, setProfessors] = useState<Professor[]>([]);
   const [selectedProfessorIds, setSelectedProfessorIds] = useState<string[]>([]);
   const [loadingProfessors, setLoadingProfessors] = useState(false);
+  const [majors, setMajors] = useState<Major[]>([]);
+  const [selectedMajorIds, setSelectedMajorIds] = useState<string[]>(
+    course?.majors?.map(m => String(m.id)) ?? []
+  );
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [loadingUniversities, setLoadingUniversities] = useState(false);
 
@@ -115,6 +119,24 @@ export function CourseForm({ course, onSubmit, onCancel, isLoading = false, init
     load();
   }, [formData.universityId, isCreateMode]);
 
+  // Load the university's Majors (degree programs) so they can be picked here.
+  useEffect(() => {
+    if (!formData.universityId) {
+      setMajors([]);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const list = await apiClient.getUniversityMajors(Number(formData.universityId));
+        if (!cancelled) setMajors(list);
+      } catch {
+        // Non-critical: majors are optional
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [formData.universityId]);
+
   const handleProfessorsChange = (ids: string[]) => {
     setSelectedProfessorIds(ids);
     onProfessorsChange?.(ids.map(Number));
@@ -152,6 +174,7 @@ export function CourseForm({ course, onSubmit, onCancel, isLoading = false, init
         titleTracks: titleTracks.length > 0 ? titleTracks.join(',') : '',
         enableEnem,
         enemArea: enableEnem ? (enemArea || null) : null,
+        majorIds: selectedMajorIds.map(Number),
       });
     } catch (error) {
       console.error('Form submission error:', error);
@@ -307,6 +330,26 @@ export function CourseForm({ course, onSubmit, onCancel, isLoading = false, init
                 placeholder={t('titleTracksPlaceholder')}
               />
               <p className="text-xs text-muted-foreground">{t('titleTracksHelp')}</p>
+            </FormItem>
+          </FormField>
+
+          {/* Majors (degree programs / graduações) this course belongs to */}
+          <FormField>
+            <FormItem>
+              <FormLabel>
+                {t('majorsLabel')}
+                <span className="ml-1 text-xs font-normal text-muted-foreground">({t('optional')})</span>
+              </FormLabel>
+              <MultiSelect
+                options={majors.map(m => ({ value: String(m.id), label: m.name }))}
+                selected={selectedMajorIds}
+                onChange={setSelectedMajorIds}
+                placeholder={t('majorsPlaceholder')}
+                searchPlaceholder={t('majorsSearch')}
+                emptyMessage={t('majorsEmpty')}
+                disabled={isLoading || !formData.universityId}
+              />
+              <p className="text-xs text-muted-foreground">{t('majorsHelp')}</p>
             </FormItem>
           </FormField>
 

--- a/i18n/messages/en.json
+++ b/i18n/messages/en.json
@@ -223,7 +223,12 @@
         "business": "Business",
         "language": "Languages",
         "humanities": "Humanities"
-      }
+      },
+      "majorsLabel": "Majors / Degree programs",
+      "majorsPlaceholder": "Select majors...",
+      "majorsSearch": "Search major...",
+      "majorsEmpty": "No majors found. Add them on the institution page.",
+      "majorsHelp": "Majors this course belongs to. The tutor uses this to answer which major/degree the course is part of."
     },
     "edit": {
       "title": "Edit Course",
@@ -972,7 +977,8 @@
         "contactPerson": "Contact Person",
         "website": "Website",
         "address": "Address",
-        "taxId": "Tax ID / CNPJ"
+        "taxId": "Tax ID / CNPJ",
+        "id": "Institution ID"
       },
       "courseColumns": {
         "name": "Course",
@@ -1007,7 +1013,22 @@
         "emptyMessage": "No professors registered yet."
       },
       "deleteConfirm": "Are you sure you want to delete this course? This action cannot be undone.",
-      "deleteError": "Error deleting course. Please try again."
+      "deleteError": "Error deleting course. Please try again.",
+      "majors": {
+        "title": "Majors",
+        "description": "Degree programs the institution offers. Courses are tagged with these majors.",
+        "add": "Add",
+        "addDefaults": "Add defaults",
+        "placeholder": "New major (e.g. Civil Engineering)",
+        "empty": "No majors yet. Add one above or use the standard list.",
+        "deleteConfirm": "Remove \"{name}\"?",
+        "deleteDescription": "This removes the major and untags it from courses.",
+        "deleteAria": "Remove {name}",
+        "addError": "Could not add the major.",
+        "deleteError": "Could not remove the major.",
+        "seedSuccess": "Standard majors added.",
+        "seedError": "Could not add the standard majors."
+      }
     },
     "form": {
       "breadcrumb": "Institutions",

--- a/i18n/messages/es.json
+++ b/i18n/messages/es.json
@@ -165,7 +165,12 @@
         "business": "Negocios",
         "language": "Lenguas",
         "humanities": "Humanidades"
-      }
+      },
+      "majorsLabel": "Carreras / Programas",
+      "majorsPlaceholder": "Selecciona las carreras...",
+      "majorsSearch": "Buscar carrera...",
+      "majorsEmpty": "No se encontraron carreras. Agrégalas en la página de la institución.",
+      "majorsHelp": "Carreras a las que pertenece este curso. El tutor lo usa para responder a qué carrera pertenece el curso."
     },
     "edit": {
       "title": "Editar Curso",
@@ -914,7 +919,8 @@
         "contactPerson": "Persona de Contacto",
         "website": "Sitio Web",
         "address": "Dirección",
-        "taxId": "NIF / Identificación Fiscal"
+        "taxId": "NIF / Identificación Fiscal",
+        "id": "ID de la Institución"
       },
       "courseColumns": {
         "name": "Curso",
@@ -949,7 +955,22 @@
         "emptyMessage": "Aún no hay profesores registrados."
       },
       "deleteConfirm": "¿Estás seguro de que deseas eliminar este curso? Esta acción no se puede deshacer.",
-      "deleteError": "Error al eliminar el curso. Por favor, intenta de nuevo."
+      "deleteError": "Error al eliminar el curso. Por favor, intenta de nuevo.",
+      "majors": {
+        "title": "Carreras",
+        "description": "Programas/carreras que ofrece la institución. Los cursos se asocian a estas carreras.",
+        "add": "Agregar",
+        "addDefaults": "Agregar predeterminadas",
+        "placeholder": "Nueva carrera (ej.: Ingeniería Civil)",
+        "empty": "Aún no hay carreras. Agrega una arriba o usa la lista estándar.",
+        "deleteConfirm": "¿Quitar \"{name}\"?",
+        "deleteDescription": "Esto elimina la carrera y la desvincula de los cursos.",
+        "deleteAria": "Quitar {name}",
+        "addError": "No se pudo agregar la carrera.",
+        "deleteError": "No se pudo quitar la carrera.",
+        "seedSuccess": "Carreras estándar agregadas.",
+        "seedError": "No se pudieron agregar las carreras estándar."
+      }
     },
     "form": {
       "breadcrumb": "Instituciones Educativas",

--- a/i18n/messages/pt-br.json
+++ b/i18n/messages/pt-br.json
@@ -165,7 +165,12 @@
         "business": "Negócios",
         "language": "Línguas",
         "humanities": "Humanas"
-      }
+      },
+      "majorsLabel": "Graduações / Cursos",
+      "majorsPlaceholder": "Selecione as graduações...",
+      "majorsSearch": "Buscar graduação...",
+      "majorsEmpty": "Nenhuma graduação encontrada. Cadastre-as na página da instituição.",
+      "majorsHelp": "Graduações a que esta disciplina pertence. O tutor usa isso para responder a que curso/graduação a disciplina se refere."
     },
     "edit": {
       "title": "Editar Disciplina",
@@ -914,7 +919,8 @@
         "contactPerson": "Pessoa de Contato",
         "website": "Website",
         "address": "Endereço",
-        "taxId": "CNPJ / Identificação Fiscal"
+        "taxId": "CNPJ / Identificação Fiscal",
+        "id": "ID da Instituição"
       },
       "courseColumns": {
         "name": "Disciplina",
@@ -949,7 +955,22 @@
         "emptyMessage": "Nenhum professor cadastrado ainda."
       },
       "deleteConfirm": "Tem certeza que deseja deletar esta disciplina? Esta ação não pode ser desfeita.",
-      "deleteError": "Erro ao deletar disciplina. Tente novamente."
+      "deleteError": "Erro ao deletar disciplina. Tente novamente.",
+      "majors": {
+        "title": "Graduações",
+        "description": "Cursos/graduações oferecidos pela instituição. As disciplinas são associadas a estas graduações.",
+        "add": "Adicionar",
+        "addDefaults": "Adicionar padrões",
+        "placeholder": "Nova graduação (ex.: Engenharia Civil)",
+        "empty": "Nenhuma graduação cadastrada ainda. Adicione uma acima ou use a lista padrão.",
+        "deleteConfirm": "Remover \"{name}\"?",
+        "deleteDescription": "Isso remove a graduação e desassocia as disciplinas dela.",
+        "deleteAria": "Remover {name}",
+        "addError": "Não foi possível adicionar a graduação.",
+        "deleteError": "Não foi possível remover a graduação.",
+        "seedSuccess": "Graduações padrão adicionadas.",
+        "seedError": "Não foi possível adicionar as graduações padrão."
+      }
     },
     "form": {
       "breadcrumb": "Instituições de Ensino",

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -12,6 +12,7 @@ import type {
   UniversityUpdate,
   UniversityWithCourses,
   Course,
+  Major,
   CourseCreate,
   CourseUpdate,
   CourseWithDetails,
@@ -654,6 +655,24 @@ class TutoriaAPIClient {
 
   async unassignProfessorFromCourse(courseId: number, professorId: number): Promise<void> {
     return this.delete(`/api/courses/${courseId}/professors/${professorId}`);
+  }
+
+  // Majors (degree programs / graduações) — managed per university
+  async getUniversityMajors(universityId: number): Promise<Major[]> {
+    return this.get(`/api/universities/${universityId}/majors`);
+  }
+
+  async createUniversityMajor(universityId: number, name: string): Promise<Major> {
+    return this.post(`/api/universities/${universityId}/majors`, { name });
+  }
+
+  async deleteUniversityMajor(universityId: number, majorId: number): Promise<void> {
+    return this.delete(`/api/universities/${universityId}/majors/${majorId}`);
+  }
+
+  /** Add the standard majors list (any not already present) and return the full list. */
+  async seedUniversityMajors(universityId: number): Promise<Major[]> {
+    return this.post(`/api/universities/${universityId}/majors/seed-defaults`);
   }
 
   // Module endpoints

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -224,6 +224,15 @@ export interface UniversityUpdate {
 
 export interface UniversityWithCourses extends University {
   courses: Course[];
+  majors?: Major[];
+}
+
+// Major (degree program / graduação) Types
+export interface Major {
+  id: number;
+  universityId: number;
+  name: string;
+  createdAt?: string;
 }
 
 // Course Types
@@ -238,6 +247,7 @@ export interface Course {
   titleTracks?: string | null;
   enableEnem?: boolean;
   enemArea?: string | null;
+  majors?: Major[];
   createdAt: string;
   updatedAt: string;
   modulesCount?: number;
@@ -254,6 +264,7 @@ export interface CourseCreate {
   titleTracks?: string | null;
   enableEnem?: boolean;
   enemArea?: string | null;
+  majorIds?: number[];
 }
 
 export interface CourseUpdate {
@@ -264,6 +275,7 @@ export interface CourseUpdate {
   titleTracks?: string | null;
   enableEnem?: boolean;
   enemArea?: string | null;
+  majorIds?: number[];
 }
 
 // Semesters (term ranges; drive the "The One" champion title)


### PR DESCRIPTION
- University detail: Majors management section (add / remove / add standard defaults) + a University Id field.
- Course create & edit forms: searchable multi-select to pick the Majors a course belongs to (pre-filled on edit).
- apiClient: majors CRUD (get/create/delete/seed-defaults); majorIds on create/update course. Major type; i18n in en/es/pt-br.